### PR TITLE
Address issues #1 and #6 regarding Swagger hanging and inefficient file reading

### DIFF
--- a/LogCollection/Constants.cs
+++ b/LogCollection/Constants.cs
@@ -14,6 +14,9 @@
         public const string EOF_WIN = @"\r\n"; //Environment.NewLine will return correct end of file byte according to host OS type. \n for Unix, \r\n for Windows
         public const string EOF_UNIX = "\n";
 
+        public const int DEFAULT_LINES = 500;
+        public const int DEFAULT_BUFFER = 4096;
+
         public const int ONE_GB = 1073741824; //Bytes
         public const int MEMORY_STREAM_SIZE = 1024*20;
         public const int MEMORY_STREAM_TIMEOUT = 300000;

--- a/LogCollection/Controllers/FileRetrievalController.cs
+++ b/LogCollection/Controllers/FileRetrievalController.cs
@@ -49,7 +49,6 @@ namespace LogCollection.Controllers
             }
             
             Console.WriteLine(logResult);
-
             return new ContentResult() { Content = logResult, StatusCode = HttpContext.Response.StatusCode };
         }
 

--- a/LogCollection/Helpers/CustomFileHandler.cs
+++ b/LogCollection/Helpers/CustomFileHandler.cs
@@ -1,0 +1,148 @@
+﻿using LogCollection.Interfaces;
+using Newtonsoft.Json.Linq;
+using System.IO.MemoryMappedFiles;
+using System.Text;
+using static LogCollection.Constants;
+
+namespace LogCollection.Helpers
+{
+    public class CustomFileHandler : IFileHandler<LogRequest>
+    {
+        private Guid _correlationId => Guid.NewGuid();
+
+        public CustomFileHandler() { }
+
+        public Guid GetCorrelationId()
+        {
+            return _correlationId;
+        }
+
+        /// <summary>
+        /// Because we are performing sequential file operations, StreamReader provides a significantly faster approach over MemoryMapping. 
+        /// This also makes filtering and line counting much easier.
+        /// Depending on your machine's RAM, this function will not have enough memory to process large files (>1GB). The rampup in RAM usage is quick, and sustained peak is much higher compared to MemoryMap.
+        /// <param name="logRequest"></param>
+        /// <returns>string result of log data, optionally filtered by keyword and restricted to a certain line count.</returns>
+        public string ProcessRequest(LogRequest logRequest)
+        {
+            string logResult = string.Empty;
+            string fullPath = logRequest.GetFullPath();
+            string fileName = logRequest.GetFileName();
+            int? linesRequested = logRequest.GetMaxLinesToReturn();
+            string? keyword = logRequest.GetSearchTerm();
+
+            long fileSize = new FileInfo(fullPath).Length;
+
+            if (linesRequested <= 0)
+            {
+                return string.Empty;
+            }
+
+            bool test = string.IsNullOrWhiteSpace(keyword);
+
+            //Need to address this logic and implement Default Lines value for LogRequest object.
+            bool returnEntireFile = (linesRequested == null || linesRequested > fileSize) && string.IsNullOrWhiteSpace(keyword);
+            bool filterRequired = !string.IsNullOrWhiteSpace(keyword);
+            bool lineCountRequired = linesRequested > 0;
+            bool bothOptionsPresent = filterRequired && lineCountRequired;
+
+            int linesAdded = 0;
+
+            
+            StringBuilder resultBuilder = new StringBuilder();
+            string[] buffer = new string[4096];
+            string? line;
+            
+            using (StreamReader sr = new StreamReader(fullPath))
+            {
+                while ((line = sr.ReadLine()) != null)
+                {
+                    bool keywordFound = filterRequired && line.Contains(keyword);
+
+                    if (returnEntireFile)
+                    {
+                        resultBuilder.Append(line + "\n");
+                    }
+
+                    if (bothOptionsPresent && line.Contains(keyword))
+                    {
+                        if (linesAdded < linesRequested)
+                        {
+                            resultBuilder.Append(line + "\n");
+                            linesAdded += 1;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                    if (lineCountRequired && !filterRequired)
+                    {
+                        if (linesAdded < linesRequested)
+                        {
+                            resultBuilder.Append(line + "\n");
+                            linesAdded += 1;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    if (keywordFound && !lineCountRequired)
+                    {
+                        resultBuilder.Append(line + "\n");
+                    }
+                }
+            }
+
+            logResult = resultBuilder.ToString();
+            resultBuilder.Clear();
+
+            return logResult;
+
+        }
+
+        /// <summary>
+        /// MemoryMapping is superior for randomly accessing sub sections of massive files.
+        /// My implementation below treated the entire file as a single subset...
+        /// Depending on your machine's RAM, this function will time out eventually on large files. RAM consumption gradually increases compared to StreamReader's sharp increase, sustained peak, and eventually noisy exception.
+        /// </summary>
+        /// <param name="logRequest"></param>
+        /// <returns>string result of log data, optionally filtered by keyword and restricted to a certain line count.</returns>
+        public string ProcessRequest_1GB_Test(LogRequest logRequest)
+        {
+
+            string logResult = string.Empty;
+            string fullPath = logRequest.GetFullPath();
+            string fileName = logRequest.GetFileName();
+            int? linesRequested = logRequest.GetMaxLinesToReturn();
+            string? keyword = logRequest.GetSearchTerm();
+
+            long fileSize = new FileInfo(fullPath).Length;
+
+            StringBuilder resultBuilder = new StringBuilder();
+            using (MemoryMappedFile mappedFile = MemoryMappedFile.CreateFromFile(fullPath))
+            using (MemoryMappedViewAccessor mapView = mappedFile.CreateViewAccessor(0, fileSize, MemoryMappedFileAccess.Read))
+            using (MemoryMappedViewStream viewStream = mappedFile.CreateViewStream(0, fileSize, MemoryMappedFileAccess.Read))
+            {
+                for (int i = 0; i < fileSize; i++)
+                {
+                    //Read one byte at a time until the end of the stream.
+                    int result = viewStream.ReadByte();
+
+                    if (result == -1)
+                    {
+                        break;
+                    }
+                    resultBuilder.Append((char)result);
+                }
+            }
+
+            logResult = resultBuilder.ToString();
+            resultBuilder.Clear();
+
+            return logResult;
+        }
+    }
+}

--- a/LogCollection/Helpers/CustomFileHandler.cs
+++ b/LogCollection/Helpers/CustomFileHandler.cs
@@ -25,7 +25,7 @@ namespace LogCollection.Helpers
         /// <returns>string result of log data, optionally filtered by keyword and restricted to a certain line count.</returns>
         public string ProcessRequest(LogRequest logRequest)
         {
-            string logResult = string.Empty;
+            string logResult = String.Empty;
             string fullPath = logRequest.GetFullPath();
             string fileName = logRequest.GetFileName();
             int? linesRequested = logRequest.GetMaxLinesToReturn();
@@ -35,7 +35,7 @@ namespace LogCollection.Helpers
 
             if (linesRequested <= 0)
             {
-                return string.Empty;
+                return String.Empty;
             }
 
             bool test = string.IsNullOrWhiteSpace(keyword);
@@ -46,12 +46,16 @@ namespace LogCollection.Helpers
             bool lineCountRequired = linesRequested > 0;
             bool bothOptionsPresent = filterRequired && lineCountRequired;
 
-            int linesAdded = 0;
-
             
             StringBuilder resultBuilder = new StringBuilder();
-            string[] buffer = new string[4096];
+            List<string> linesToPrint = new List<string>();
+            
+            int linesAdded = 0;            
             string? line;
+            
+            //Commented lines are a sneak peek of two new "Reverse" StreamReaders that would avoid the List.Add and reverse iteration operations used in this code.
+            //using(ReverseTextReader rtr = new ReverseTextReader(fullPath))
+            //using(ReverseFileReader rfr = new ReverseFileReader(fullPath))
             
             using (StreamReader sr = new StreamReader(fullPath))
             {
@@ -61,14 +65,14 @@ namespace LogCollection.Helpers
 
                     if (returnEntireFile)
                     {
-                        resultBuilder.Append(line + "\n");
+                        linesToPrint.Add(line + "\n");
                     }
 
                     if (bothOptionsPresent && line.Contains(keyword))
                     {
                         if (linesAdded < linesRequested)
                         {
-                            resultBuilder.Append(line + "\n");
+                            linesToPrint.Add(line + "\n");
                             linesAdded += 1;
                         }
                         else
@@ -80,7 +84,7 @@ namespace LogCollection.Helpers
                     {
                         if (linesAdded < linesRequested)
                         {
-                            resultBuilder.Append(line + "\n");
+                            linesToPrint.Add(line + "\n");
                             linesAdded += 1;
                         }
                         else
@@ -91,9 +95,14 @@ namespace LogCollection.Helpers
 
                     if (keywordFound && !lineCountRequired)
                     {
-                        resultBuilder.Append(line + "\n");
+                        linesToPrint.Add(line + "\n");
                     }
                 }
+            }
+
+            for (int i = linesToPrint.Count - 1; i > 1; i--)
+            {
+                resultBuilder.Append(linesToPrint[i]);
             }
 
             logResult = resultBuilder.ToString();
@@ -112,37 +121,39 @@ namespace LogCollection.Helpers
         /// <returns>string result of log data, optionally filtered by keyword and restricted to a certain line count.</returns>
         public string ProcessRequest_1GB_Test(LogRequest logRequest)
         {
+            //Cut over to StreamReader for now since 1GB test and MemoryMapping are dormant for now.
+            return ProcessRequest(logRequest);
 
-            string logResult = string.Empty;
-            string fullPath = logRequest.GetFullPath();
-            string fileName = logRequest.GetFileName();
-            int? linesRequested = logRequest.GetMaxLinesToReturn();
-            string? keyword = logRequest.GetSearchTerm();
+            //string logResult = string.Empty;
+            //string fullPath = logRequest.GetFullPath();
+            //string fileName = logRequest.GetFileName();
+            //int? linesRequested = logRequest.GetMaxLinesToReturn();
+            //string? keyword = logRequest.GetSearchTerm();
 
-            long fileSize = new FileInfo(fullPath).Length;
+            //long fileSize = new FileInfo(fullPath).Length;
 
-            StringBuilder resultBuilder = new StringBuilder();
-            using (MemoryMappedFile mappedFile = MemoryMappedFile.CreateFromFile(fullPath))
-            using (MemoryMappedViewAccessor mapView = mappedFile.CreateViewAccessor(0, fileSize, MemoryMappedFileAccess.Read))
-            using (MemoryMappedViewStream viewStream = mappedFile.CreateViewStream(0, fileSize, MemoryMappedFileAccess.Read))
-            {
-                for (int i = 0; i < fileSize; i++)
-                {
-                    //Read one byte at a time until the end of the stream.
-                    int result = viewStream.ReadByte();
+            //StringBuilder resultBuilder = new StringBuilder();
+            //using (MemoryMappedFile mappedFile = MemoryMappedFile.CreateFromFile(fullPath))
+            //using (MemoryMappedViewAccessor mapView = mappedFile.CreateViewAccessor(0, fileSize, MemoryMappedFileAccess.Read))
+            //using (MemoryMappedViewStream viewStream = mappedFile.CreateViewStream(0, fileSize, MemoryMappedFileAccess.Read))
+            //{
+            //    for (int i = 0; i < fileSize; i++)
+            //    {
+            //        //Read one byte at a time until the end of the stream.
+            //        int result = viewStream.ReadByte();
 
-                    if (result == -1)
-                    {
-                        break;
-                    }
-                    resultBuilder.Append((char)result);
-                }
-            }
+            //        if (result == -1)
+            //        {
+            //            break;
+            //        }
+            //        resultBuilder.Append((char)result);
+            //    }
+            //}
 
-            logResult = resultBuilder.ToString();
-            resultBuilder.Clear();
+            //logResult = resultBuilder.ToString();
+            //resultBuilder.Clear();
 
-            return logResult;
+            //return logResult;
         }
     }
 }

--- a/LogCollection/Program.cs
+++ b/LogCollection/Program.cs
@@ -1,4 +1,5 @@
-﻿using LogCollection.Interfaces;
+﻿using LogCollection.Helpers;
+using LogCollection.Interfaces;
 
 namespace LogCollection
 {

--- a/LogCollection/Tests/CustomFileHandlerTests.cs
+++ b/LogCollection/Tests/CustomFileHandlerTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using System;
 using LogCollection.Interfaces;
 using static LogCollection.Tests.TestConstants;
+using LogCollection.Helpers;
 
 namespace LogCollection.Tests
 {


### PR DESCRIPTION
StreamReader is now in use and returns the 19MB install log results in < 300ms, compared to the original 3 second return time when (accidentally) still using the IO.File library.

-Added a Helper folder and moved my Custom File Handler there in anticipation of it being accompanied by future "Reverse Stream Reader" functionality.
-Basic formatting tweaks and random comments
![image](https://user-images.githubusercontent.com/13991686/196576632-3a593c1f-0f5f-4966-8b33-092b02080212.png)
