### PR TITLE
Issue 3 and 5: Implemented Filepath validation and updated execution/port instructions

### DIFF
--- a/LogCollection/.config/dotnet-tools.json
+++ b/LogCollection/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "6.0.10",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}

--- a/LogCollection/Constants.cs
+++ b/LogCollection/Constants.cs
@@ -3,7 +3,7 @@
     public class Constants
     {
         //To run this application correctly, please update the PROD_SOURCE_DIRECTORY to a location that contains your target log files to read.
-        public const string PROD_SOURCE_DIRECTORY = @"C:\Users\Ravi\Desktop\temp\";
+        public const string PROD_SOURCE_DIRECTORY = @".../var/log/";
         public const string STG_SOURCE_DIRECTORY = @"C:\Users\Ravi\Desktop\temp\";
         
         public const string TEST_LOG = @"C:\Users\Ravi\Desktop\temp\log.txt";

--- a/LogCollection/Constants.cs
+++ b/LogCollection/Constants.cs
@@ -3,22 +3,26 @@
     public class Constants
     {
         //To run this application correctly, please update the PROD_SOURCE_DIRECTORY to a location that contains your target log files to read.
-        public const string PROD_SOURCE_DIRECTORY = @".../var/log/";
+        public const string PROD_SOURCE_DIRECTORY = @"C:\Users\Ravi\Desktop\temp\";
         public const string STG_SOURCE_DIRECTORY = @"C:\Users\Ravi\Desktop\temp\";
         
         public const string TEST_LOG = @"C:\Users\Ravi\Desktop\temp\log.txt";
         public const string TEST_LOG_SMALL = @"C:\Users\Ravi\Desktop\temp\log-small.txt";
         public const string TEST_FILE_1GB = @"C:\Users\Ravi\Desktop\temp\file-big.txt";
-        public const string NOT_FOUND = @"C:\Users\Ravi\Desktop\temp\DoesNotExist.txt";
+        public const string TEST_FILE_NOT_FOUND = @"C:\Users\Ravi\Desktop\temp\DoesNotExist.txt";
         
         public const string EOF_WIN = @"\r\n"; //Environment.NewLine will return correct end of file byte according to host OS type. \n for Unix, \r\n for Windows
-        public const string EOF_UNIX = "\n";
+        public const string EOF_UNIX = @"\n";
 
-        public const int DEFAULT_LINES = 500;
+        //Opted against using DEFAULT_LINES, see Issue #3 for details.
+        //public const int DEFAULT_LINES = 500;
         public const int DEFAULT_BUFFER = 4096;
 
         public const int ONE_GB = 1073741824; //Bytes
         public const int MEMORY_STREAM_SIZE = 1024*20;
         public const int MEMORY_STREAM_TIMEOUT = 300000;
+
+        //Errors
+        public const string ERR_NOT_FOUND = "File or directory not found.";
     }
 }

--- a/LogCollection/Helpers/CustomFileHandler.cs
+++ b/LogCollection/Helpers/CustomFileHandler.cs
@@ -1,4 +1,5 @@
-﻿using LogCollection.Interfaces;
+﻿using LogCollection.Controllers;
+using LogCollection.Interfaces;
 using Newtonsoft.Json.Linq;
 using System.IO.MemoryMappedFiles;
 using System.Text;
@@ -38,27 +39,24 @@ namespace LogCollection.Helpers
                 return String.Empty;
             }
 
-            bool test = string.IsNullOrWhiteSpace(keyword);
-
-            //Need to address this logic and implement Default Lines value for LogRequest object.
-            bool returnEntireFile = (linesRequested == null || linesRequested > fileSize) && string.IsNullOrWhiteSpace(keyword);
+            bool returnEntireFile = (linesRequested == null && string.IsNullOrWhiteSpace(keyword));
             bool filterRequired = !string.IsNullOrWhiteSpace(keyword);
             bool lineCountRequired = linesRequested > 0;
-            bool bothOptionsPresent = filterRequired && lineCountRequired;
-
+            bool bothOptionsPresent = (filterRequired && lineCountRequired);
             
             StringBuilder resultBuilder = new StringBuilder();
             List<string> linesToPrint = new List<string>();
             
             int linesAdded = 0;            
             string? line;
-            
+
             //Commented lines are a sneak peek of two new "Reverse" StreamReaders that would avoid the List.Add and reverse iteration operations used in this code.
             //using(ReverseTextReader rtr = new ReverseTextReader(fullPath))
             //using(ReverseFileReader rfr = new ReverseFileReader(fullPath))
             
             using (StreamReader sr = new StreamReader(fullPath))
             {
+                //Could use _logger.LogTrace here for more granular reporting    
                 while ((line = sr.ReadLine()) != null)
                 {
                     bool keywordFound = filterRequired && line.Contains(keyword);
@@ -121,7 +119,7 @@ namespace LogCollection.Helpers
         /// <returns>string result of log data, optionally filtered by keyword and restricted to a certain line count.</returns>
         public string ProcessRequest_1GB_Test(LogRequest logRequest)
         {
-            //Cut over to StreamReader for now since 1GB test and MemoryMapping are dormant for now.
+            //Cut over to StreamReader since 1GB test and MemoryMapping are dormant for now.
             return ProcessRequest(logRequest);
 
             //string logResult = string.Empty;

--- a/README.md
+++ b/README.md
@@ -17,11 +17,21 @@ This Web API solution written in C# / .NET Core 6.0.7 allows a user to retrieve 
     2. 🎉 Your solution should be running! 💨
     3. This method is considered Debugging/Development mode, so your browser will open up the Swagger URL: `https://localhost:####/swagger/index.html`
     3. Consult the next section for instructions on how to use Swagger or Postman to interact with the API.
+
 #### Via Executable File ####
     1. Navigate to your LogCollection application file (\...\LogCollection\LogCollection\bin\Release\net6.0\) and double click it.
     2. The API should be running! 🏃🏽‍♂️
-    3. Open your Command Prompt window and note down the localhost URL that is being used. 
-    4. You will need this URL for the Postman instructions below - we are not using the Swagger UI because this is the RELEASE/"Production" version of the application. If you notice in the `Program.cs` file, this is why the Swagger isn't generated.
+    3. View your Command Prompt window and note down the localhost URL that is being used.
+    4. Use the first line of information -> `Now listening on https://localhost:7182`
+    5. You will need this URL for the Postman instructions below - we are not using the Swagger UI because this is the RELEASE/"Production" version of the application. If you notice in the `Program.cs` file, this is why the Swagger isn't generated.
+
+#### Via Command Line ####
+    1. Navigate to your LogCollection application file (\...\LogCollection\LogCollection\bin\Release\net6.0\)
+    2. Execute the following command `dotnet run .\LogCollection.exe --project "\...\LogCollection\LogCollection\LogCollection.csproj"`
+        2.5. You may optionally add `--urls=https://localhost:4DigitsHere` to use your own port number.
+    4. View your Command Prompt window and note down the localhost URL that is being used.
+    5. Use the first line of information -> `Now listening on https://localhost:7182`
+    6. You will need this URL for the Postman instructions below - we are not using the Swagger UI because this is the RELEASE/"Production" version of the application. If you notice in the `Program.cs` file, this is why the Swagger isn't generated.
 
 📝 Note: 
 
@@ -29,6 +39,27 @@ This Web API solution written in C# / .NET Core 6.0.7 allows a user to retrieve 
 			A new `LogRequest` object will be created with the parameters you provided, and the file handler will get to work!
 ## 😎 Swagger / Postman 📮 ## 
 	
+Example `curl` commands for your reference:
+
+Log: `curl -X 'GET' \
+  'https://localhost:7182/FileRetrieval/api/get-log-by-name?fileName=install.log&linesToReturn=15' \
+  -H 'accept: */*'`
+
+Log with lines: `curl -X 'GET' \
+  'https://localhost:7182/FileRetrieval/api/get-log-by-name?fileName=install.log&linesToReturn=15' \
+  -H 'accept: */*'`
+
+Log with filter: `curl -X 'GET' \
+  'https://localhost:7182/FileRetrieval/api/get-log-by-name?fileName=install.log&searchTerm=error' \
+  -H 'accept: */*'`
+
+
+Log with lines and filter: `curl -X 'GET' \
+  'https://localhost:7182/FileRetrieval/api/get-log-by-name?fileName=install.log&linesToReturn=15&searchTerm=error' \
+  -H 'accept: */*'`
+
+
+
 Swagger
 1. Using the browser window that Visual Studio opened for you, click on the API you'd like to test. 
 2. Enter your parameters and observe the results!
@@ -37,7 +68,7 @@ Swagger
 Postman
 1. Using Postman or another REST client, send GET requests per the specifications outlined in Swagger. 
 
-    1.1. If you are running the application via executable, check your command prompt window. It will tell you which localhost route to use on Postman.
+    1.5. If you are running the application via executable, check the first line of your command prompt window. It will tell you which localhost route to use on Postman.
 
 2. Your Postman should look something like this:
 GET `https://localhost:####/FileRetrieval/api/get-log-by-name?fileName=log-small.txt&linesToReturn=5&searchTerm=2022-10-15`


### PR DESCRIPTION
*Issues 2, 3, and 5
Filepath will be validated before processing. Throws FileNotFound exception.

Decided not to implement Default Line fallback value. Per the instructions and being able to test large files, it should be expected that if the request isn't supplied with a line count, the user would like ALL of the lines from the file. 

This is more aligned to a typical workflow imo, a user likely won't know exactly how many lines present in a file beforehand. So if they want the entire file, they will just leave that parameter blank.


README changes:
Reconfirming the below
- Using Visual Studio Debug mode -> https://localhost:7182
- Using IIS -> http://localhost:40311

- Added 4 curl commands to outline each of the four valid request scenarios.